### PR TITLE
8: Creacion endpoint para cambiar el orden de prioridad de uno o mas …

### DIFF
--- a/role/fullstack/senior/reynaldoqs/airportart-api/src/controllers/airportsController.ts
+++ b/role/fullstack/senior/reynaldoqs/airportart-api/src/controllers/airportsController.ts
@@ -1,8 +1,22 @@
 import AirtPort from "../models/AirtPort";
 
 // Cambia el operador de un aeropuerto a otro
-export const changeOperator = async (airportId: number, operatorId: number) => {
-  const airport = await AirtPort.findByPk(airportId);
-  if (!airport) throw `${airportId} do es not exist.`;
-  return airport.update({ AirportOperatorID: operatorId });
+export const changeOperator = (airportId: number, operatorId: number) => {
+  return AirtPort.update(
+    { AirportOperatorID: operatorId },
+    { where: { ID: airportId } }
+  );
+};
+
+type OrderChange = {
+  airportId: number;
+  newOrder: number;
+};
+// Metodo para cambiar el PriorityOrder de un aeropuerto
+export const changePriorityOrder = async (...priorityOrders: OrderChange[]) => {
+  const updatePromises = priorityOrders.map(({ airportId, newOrder }) =>
+    AirtPort.update({ PriorityOrder: newOrder }, { where: { ID: airportId } })
+  );
+  await Promise.all(updatePromises);
+  return AirtPort.findAll({ raw: true });
 };

--- a/role/fullstack/senior/reynaldoqs/airportart-api/src/routes/airpotsRouter.ts
+++ b/role/fullstack/senior/reynaldoqs/airportart-api/src/routes/airpotsRouter.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 
-import { changeOperator } from "../controllers";
+import { changeOperator, changePriorityOrder } from "../controllers";
 
 const airportsRouter = Router();
 
@@ -19,4 +19,15 @@ airportsRouter.patch("/:airportId", async (req, res) => {
   }
 });
 
+// patch para cambiar los ordenes de prioridad
+airportsRouter.post("/set-priorities", async (req, res) => {
+  try {
+    // array de orden de prioridades
+    const { priorityOrders } = req.body;
+    const response = await changePriorityOrder(...priorityOrders);
+    return res.status(200).json({ response });
+  } catch (error) {
+    return res.status(400).json({ error });
+  }
+});
 export default airportsRouter;


### PR DESCRIPTION
# Descripcion

Creacion del endpoint `airport/set-priorities`, para cambiar el orden de prioridad de uno o mas aeropuertos.