### PR TITLE
10: Agregando orden de listado de aeropuertos en el API

### DIFF
--- a/role/fullstack/senior/reynaldoqs/airportart-api/src/controllers/airportsController.ts
+++ b/role/fullstack/senior/reynaldoqs/airportart-api/src/controllers/airportsController.ts
@@ -22,11 +22,17 @@ export const changePriorityOrder = async (...priorityOrders: OrderChange[]) => {
   return AirtPort.findAll();
 };
 
+export type OrderConfig = "ASC" | "DESC";
+
 // Metodo para obtener todos los aeropuertos
-export const getAirports = async () => {
+export const getAirports = async (config: OrderConfig = "ASC") => {
   // Metodo para conseguir los datos de las assocciaciones, por alguna razon no esta registrando bien las associaciones
   //TODO: configure well squilize associations
-  const airports: any = await AirtPort.findAll({ raw: true });
+  console.log({ config });
+  const airports: any = await AirtPort.findAll({
+    raw: true,
+    order: [["PriorityOrder", config]],
+  });
 
   for (const airport of airports) {
     airport.location = await Location.findByPk(airport.LocationID, {

--- a/role/fullstack/senior/reynaldoqs/airportart-api/src/routes/airpotsRouter.ts
+++ b/role/fullstack/senior/reynaldoqs/airportart-api/src/routes/airpotsRouter.ts
@@ -4,15 +4,17 @@ import {
   changeOperator,
   changePriorityOrder,
   getAirports,
+  OrderConfig,
 } from "../controllers";
 
 const airportsRouter = Router();
 
 // rutas para aeropuertos
 // get para obtener todos los aeropuertos
-airportsRouter.get("/", async (_, res) => {
+airportsRouter.get("/", async (req, res) => {
   try {
-    const airports = await getAirports();
+    const order = req.query.order as OrderConfig;
+    const airports = await getAirports(order);
     return res.status(200).json({ airports });
   } catch (error) {
     return res.status(400).json({ error });


### PR DESCRIPTION
# Descripcion

Agregando configuracion para enviar orden de listado 'ASC' y 'DESC' para el listado de aeropuertos